### PR TITLE
Added license information

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -11,6 +11,7 @@
     <extension point="xbmc.addon.metadata">
         <language></language>
         <platform>all</platform>
+        <license>GNU GENERAL PUBLIC LICENSE. Version 2, June 1991</license>
         <website>http://www.cheezburger.com/</website>
         <source>https://github.com/dersphere/plugin.image.cheezburger_network</source>
         <forum>http://forum.xbmc.org/showthread.php?tid=142300</forum>


### PR DESCRIPTION
Needed to automatically fill field on http://kodi.wiki and http://addons.kodi.tv/ sites.
